### PR TITLE
move users resource to root URL path

### DIFF
--- a/src/user_http_api/service.clj
+++ b/src/user_http_api/service.clj
@@ -118,18 +118,18 @@
 
 (defroutes routes
   [[["/"
+     {:post [:post-user create-user]}
      ^:interceptors [(body-params)
                      query-param-accept
                      (negotiate-response-content-type ["application/edn"
                                                        "application/transit+json"
                                                        "application/transit+msgpack"
                                                        "application/json"])]
-     ["/ping" {:get [:ping ping]}]
-     ["/users" {:post [:post-user create-user]}]
-     ["/users/:id" {:get [:get-user read-user]
+     ["/:id" {:get [:get-user read-user]
                     :put [:put-user update-user]
                     :patch [:patch-user update-user]
-                    :delete [:delete-user delete-user]}]]]])
+              :delete [:delete-user delete-user]}]
+     ["/ping" {:get [:ping ping]}]]]])
 
 (defn service []
   {::env :prod


### PR DESCRIPTION
I realized when writing the "put this into synapse-balancer" card that
we actually wanted "users" to be the root resource here. Otherwise all
of the external API URLs would end up looking like
https://api.turbovote.org/users/users/... because the first "/users" is
what routes it to this component and the second would then be needed to
match the old routes in here. However, since this is a "user" API, it
makes sense for that to be the root resource and thus our external API
URLs will be like this: https://api.turbovote.org/users/...