### PR TITLE
Do early lein immuntant war to fetch deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /usr/src/user-http-api
 COPY project.clj /usr/src/user-http-api/
 
 RUN lein deps
+RUN lein immutant war --name no-code-just-deps --destination target --nrepl-start
 
 COPY . /usr/src/user-http-api
 


### PR DESCRIPTION
Running `lein immutant war` as the last step in the Dockerfile was downloading dependencies required for that plugin at the end. Because it was the last line, any change anywhere would cause a redownload.

After talking to the immutant guys through chat, they suggested 2 options that worked:

1. Add a dependency to wildfly, which entails all of the same dependencies as the immutant plugin. This worked in my tests, but required a new dependency that had to be kept in sync with the immutant plugin.

2. Add a `lein immutant war` call higher up, before the code is copied over. It creates an uberjar with all the deps but no code. As a sideeffect, the dependencies are downloaded and cached.

This patch is an implementation of #2.