### PR TITLE
Update pedestal-toolbox to 0.6.2 to fix a bug in Content-Type handling

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
                  [org.clojure/tools.logging "0.3.1"]
                  [turbovote.resource-config "0.2.0"]
                  [com.novemberain/langohr "3.3.0"]
-                 [prismatic/schema "0.4.3"]
+                 [prismatic/schema "0.4.4"]
                  [ch.qos.logback/logback-classic "1.1.3"]
 
                  ;; core.async has to come before pedestal or kehaar.wire-up will

--- a/project.clj
+++ b/project.clj
@@ -18,7 +18,7 @@
                  
                  [io.pedestal/pedestal.service "0.4.0"]
                  [io.pedestal/pedestal.service-tools "0.4.0"]
-                 [democracyworks/pedestal-toolbox "0.6.1"]
+                 [democracyworks/pedestal-toolbox "0.6.2"]
 
                  ;; this has to go before pedestal.immutant
                  ;; until this is fixed:


### PR DESCRIPTION
[Pivotal card](https://www.pivotaltracker.com/story/show/101555726)

This also updates prismatic/schema to 0.4.4 since I was in there anyway. It seems to be a [pretty innocuous update](https://github.com/Prismatic/schema/blob/master/CHANGELOG.md#044).