### PR TITLE
Sync timeouts between bifrost and kehaar

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -26,7 +26,7 @@
                  [org.immutant/web "2.0.2"]
                  [io.pedestal/pedestal.immutant "0.4.0"]
                  [org.immutant/core "2.0.2"]
-                 [democracyworks/bifrost "0.1.4"]]
+                 [democracyworks/bifrost "0.1.5-SNAPSHOT"]]
   :plugins [[lein-immutant "2.0.0"]]
   :main ^:skip-aot user-http-api.server
   :target-path "target/%s"

--- a/project.clj
+++ b/project.clj
@@ -26,7 +26,7 @@
                  [org.immutant/web "2.0.2"]
                  [io.pedestal/pedestal.immutant "0.4.0"]
                  [org.immutant/core "2.0.2"]
-                 [democracyworks/bifrost "0.1.5-SNAPSHOT"]]
+                 [democracyworks/bifrost "0.1.5"]]
   :plugins [[lein-immutant "2.0.0"]]
   :main ^:skip-aot user-http-api.server
   :target-path "target/%s"

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -1,10 +1,14 @@
 {:server {:hostname "0.0.0.0"
           :port 8080
           :allowed-origins #resource-config/edn #resource-config/env "ALLOWED_ORIGINS"}
+ :timeouts {:user-create 20000
+            :user-read 10000
+            :user-update 20000
+            :user-delete 10000}
  :rabbitmq {:connection {:host #resource-config/env "RABBITMQ_PORT_5672_TCP_ADDR"
                          :port #resource-config/edn #resource-config/env "RABBITMQ_PORT_5672_TCP_PORT"}
             :queues {"user-http-api.ok" {:exclusive false :durable true :auto-delete false}
                      "user-works.user.create" {:exclusive false :durable true :auto-delete false}
                      "user-works.user.read" {:exclusive false :durable true :auto-delete false}
-                     "user-works.user.update" {:exclusive false :durable true :auto-delete false}
-                     "user-works.user.delete" {:exclusive false :durable true :auto-delete false}}}}
+                     "user-works.user.update" {:exclusive false, :durable true :auto-delete false}
+                     "user-works.user.delete" {:exclusive false, :durable true :auto-delete false}}}}

--- a/src/user_http_api/queue.clj
+++ b/src/user_http_api/queue.clj
@@ -19,28 +19,28 @@
                  ""
                  "user-works.user.create"
                  (config [:rabbitmq :queues "user-works.user.create"])
-                 20000
+                 (config [:timeouts :user-create])
                  channels/create-users)
                 (wire-up/external-service
                  connection
                  ""
                  "user-works.user.read"
                  (config [:rabbitmq :queues "user-works.user.read"])
-                 10000
+                 (config [:timeouts :user-read])
                  channels/read-users)
                 (wire-up/external-service
                  connection
                  ""
                  "user-works.user.update"
                  (config [:rabbitmq :queues "user-works.user.update"])
-                 20000
+                 (config [:timeouts :user-update])
                  channels/update-users)
                 (wire-up/external-service
                  connection
                  ""
                  "user-works.user.delete"
                  (config [:rabbitmq :queues "user-works.user.delete"])
-                 10000
+                 (config [:timeouts :user-delete])
                  channels/delete-users)]}))
 
 (defn close-resources! [resources]

--- a/src/user_http_api/service.clj
+++ b/src/user_http_api/service.clj
@@ -34,20 +34,32 @@
 
 (defroutes routes
   [[["/"
-     {:post [:post-user (bifrost/interceptor channels/create-users)]}
+     {:post [:post-user
+             (bifrost/interceptor channels/create-users
+                                  (config [:timeouts :user-create]))]}
      ^:interceptors [(body-params)
                      query-param-accept
-                     (negotiate-response-content-type ["application/edn"
-                                                       "application/transit+json"
-                                                       "application/transit+msgpack"
-                                                       "application/json"
-                                                       "text/plain"])
+                     (negotiate-response-content-type
+                      ["application/edn"
+                       "application/transit+json"
+                       "application/transit+msgpack"
+                       "application/json"
+                       "text/plain"])
                      api-translator]
      ["/ping" {:get [:ping ping]}]
-     ["/:id" {:get [:get-user (bifrost/interceptor channels/read-users)]
-              :put [:put-user (bifrost/interceptor channels/update-users)]
-              :patch [:patch-user (bifrost/interceptor channels/update-users)]
-              :delete [:delete-user (bifrost/interceptor channels/delete-users)]}]]]])
+     ["/:id" {:get [:get-user
+                    (bifrost/interceptor channels/read-users
+                                         (config [:timeouts :user-read]))]
+              :put [:put-user
+                    (bifrost/interceptor channels/update-users
+                                         (config [:timeouts :user-update]))]
+              :patch [:patch-user
+                      (bifrost/interceptor channels/update-users
+                                           (config [:timeouts :user-update]))]
+              :delete [:delete-user
+                       (bifrost/interceptor
+                        channels/delete-users
+                        (config [:timeouts :user-delete]))]}]]]])
 
 (defn service []
   {::env :prod


### PR DESCRIPTION
@sduckett and I had been trying to test something w/ an upstream timeout and were bit by the previously-hard-coded 10s timeout in bifrost.

This version of bifrost (**which isn't released yet as of the opening of this PR, hence the build failure**) allows setting timeouts on each interceptor and gives us the ability to sync the timeouts between bifrost and kehaar.

**DO NOT MERGE OR DEPLOY** this until bifrost 0.1.5 is released and the build goes green.