### PR TITLE
Clojure 1.9

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/democracyworks/user-http-api"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
+  :dependencies [[org.clojure/clojure "1.9.0-alpha17"]
                  [org.clojure/tools.logging "0.3.1"]
                  [turbovote.resource-config "0.2.1"]
                  [com.novemberain/langohr "3.7.0"]

--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
                  ;; not compile. Something to do with the try-catch in
                  ;; kehaar.core/go-handler.
                  [org.clojure/core.async "0.3.442"]
-                 [democracyworks/kehaar "0.10.4"]
+                 [democracyworks/kehaar "0.11.0"]
 
                  [io.pedestal/pedestal.service "0.5.2"]
                  [io.pedestal/pedestal.service-tools "0.5.2"]

--- a/src/user_http_api/service.clj
+++ b/src/user_http_api/service.clj
@@ -10,7 +10,8 @@
             [pedestal-toolbox.content-negotiation :refer :all]
             [kehaar.core :as k]
             [user-http-api.channels :as channels]
-            [bifrost.core :as bifrost]))
+            [bifrost.core :as bifrost])
+  (:import (java.util UUID)))
 
 (def ping
   (interceptor
@@ -24,7 +25,7 @@
     (fn [ctx]
       (let [id-key-path [:request :path-params :id]]
         (if-let [user-id (get-in ctx id-key-path)]
-          (assoc-in ctx id-key-path (java.util.UUID/fromString user-id))
+          (assoc-in ctx id-key-path (UUID/fromString user-id))
           ctx)))
     :leave
     (fn [ctx]


### PR DESCRIPTION
This is needed for classic migrations because the incoming requests use the new `#:address{:street ...}` style syntax.